### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/music_commands/tps.js
+++ b/music_commands/tps.js
@@ -58,7 +58,7 @@ module.exports = class extends SlashCommand {
             {
               title: "Ticks Per Second",
               description: `Average TPS from last:`,
-              url: "https://minecraft.fandom.com/wiki/Tick",
+              url: "https://minecraft.wiki/w/Tick",
               author: {
                 name: "Pure Vanilla Status",
                 icon_url: "https://i.imgur.com/y4gEvak.png",


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.